### PR TITLE
fix: add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         uses: ./.github/actions/pnpm-node
       - name: Install dependencies
         run: pnpm install
+      - name: Build the package
+        run: pnpm build
       - name: Release
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Your pull request will be reviewed and either merged, subject to change requests
 
 Make sure:
 - you have [Node.js](https://nodejs.org/en/) at version 20.18.3+, 22.12.0+ or 24.0.0+,
-- you have [pnpm](https://pnpm.io) at version 10.28.2+ installed,
+- you have [pnpm](https://pnpm.io) at version 10.30.2+ installed,
 - you are familiar with [Git](https://git-scm.com).
 
 **Before submitting your pull request,** make sure the following requirements are fulfilled:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Node.js 20.18.3+, 22.12.0+ and 24.0.0+ are supported. **Odd major versions are n
 
 ### Supported package manager versions
 
-`npm` 10.8.2+ and `pnpm` 10.28.2+ are supported. **`yarn` is not supported.**
+`npm` 10.8.2+ and `pnpm` 10.30.2+ are supported. **`yarn` is not supported.**
 
 ## Reporting a vulnerability
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "engines": {
     "node": "^20.18.3 || ^22.12.0 || ^24.0.0",
     "npm": ">=10.8.2",
-    "pnpm": ">=10.28.2"
+    "pnpm": ">=10.30.2"
   },
   "scripts": {
     "biome": "biome check --write .",


### PR DESCRIPTION
The package was published to NPM without the output directory.