### PR TITLE
fix: fix folder browsing and `exclude` checking

### DIFF
--- a/src/utils/browse-folders.ts
+++ b/src/utils/browse-folders.ts
@@ -4,17 +4,14 @@ import path from "node:path";
 /**
  * Browses the folders recursively from the given folder.
  * @param folder - The folder from which to start the browsing.
- * @return An array of all the directories found recursively.
+ * @return An array of all the directories found recursively, including the given folder.
  */
 export const browseFolders = async (folder: string): Promise<string[]> => {
   const entries = (await fs.readdir(folder, { withFileTypes: true })).map(async entry => {
     const pathToEntry = path.join(folder, entry.name);
-    if (entry.isDirectory()) {
-      const subDirectories = await browseFolders(pathToEntry);
-      return [pathToEntry, ...subDirectories];
-    }
+    if (entry.isDirectory()) return await browseFolders(pathToEntry);
     return [];
   });
   const directories = await Promise.all(entries);
-  return directories.flat();
+  return [folder, ...directories.flat()];
 };

--- a/src/utils/get-files-to-validate.ts
+++ b/src/utils/get-files-to-validate.ts
@@ -21,10 +21,10 @@ export const getFilesToValidate = async (
 ): Promise<string[]> => {
   const { files, paths, exclude, languages } = options;
   if (files) return files.map(file => path.resolve(cwd(), file));
-  const excludeRegexps = [...(exclude ?? []), "node_modules"].map(patternToRegex);
+  const excludeRegexps = (exclude ?? []).map(patternToRegex);
   const folders = (await browseFolders(cwd())).map(async folder => {
-    const isExcluded = excludeRegexps?.some(regex => regex.test(folder)) ?? false;
-    if (isExcluded || (paths && !paths.some(path => folder.startsWith(`${cwd()}/${path}`)))) {
+    const isFolderExcluded = [...excludeRegexps, /node_modules/].some(regex => regex.test(folder));
+    if (isFolderExcluded || (paths && !paths.some(path => folder.startsWith(`${cwd()}/${path}`)))) {
       return [];
     }
     const files = await fs.readdir(folder);
@@ -36,7 +36,8 @@ export const getFilesToValidate = async (
       : Object.values(EXTENSIONS_PER_LANGUAGE).flat();
     for (const file of files) {
       const fileStat = await fs.stat(path.join(folder, file));
-      if (fileStat.isFile() && extensions.includes(path.extname(file))) {
+      const isFileExcluded = excludeRegexps.some(regex => regex.test(file));
+      if (fileStat.isFile() && extensions.includes(path.extname(file)) && !isFileExcluded) {
         filesToValidate.push(path.join(folder, file));
       }
     }

--- a/test/utils/browse-folders.test.ts
+++ b/test/utils/browse-folders.test.ts
@@ -26,9 +26,9 @@ const mockedDirent = {
   }
 };
 
-it("should return an empty array if the folder is empty", async () => {
+it("should return only the folder itself if the folder is empty", async () => {
   vi.spyOn(fs, "readdir").mockResolvedValue([]);
-  expect(await browseFolders(mockedCwd)).toStrictEqual([]);
+  expect(await browseFolders(mockedCwd)).toStrictEqual([mockedCwd]);
 });
 it("should browse folders recursively", async () => {
   vi.spyOn(fs, "readdir").mockImplementation(async dirPath => {
@@ -48,32 +48,33 @@ it("should browse folders recursively", async () => {
         }
       ];
     }
-    if (dirPath === "/fake/path/folder1") {
+    if (dirPath === `${mockedCwd}/folder1`) {
       return [
         {
           ...mockedDirent,
           name: "subfolder1" as unknown as Buffer<ArrayBuffer>,
           isDirectory: () => true,
-          parentPath: "/fake/path/folder1"
+          parentPath: `${mockedCwd}/folder1`
         }
       ];
     }
-    if (dirPath === "/fake/path/folder2") {
+    if (dirPath === `${mockedCwd}/folder2`) {
       return [
         {
           ...mockedDirent,
           name: "subfolder2" as unknown as Buffer<ArrayBuffer>,
           isDirectory: () => true,
-          parentPath: "/fake/path/folder2"
+          parentPath: `${mockedCwd}/folder2`
         }
       ];
     }
     return [];
   });
   expect(await browseFolders(mockedCwd)).toStrictEqual([
-    "/fake/path/folder1",
-    "/fake/path/folder1/subfolder1",
-    "/fake/path/folder2",
-    "/fake/path/folder2/subfolder2"
+    mockedCwd,
+    `${mockedCwd}/folder1`,
+    `${mockedCwd}/folder1/subfolder1`,
+    `${mockedCwd}/folder2`,
+    `${mockedCwd}/folder2/subfolder2`
   ]);
 });

--- a/test/utils/get-files-to-validate.test.ts
+++ b/test/utils/get-files-to-validate.test.ts
@@ -63,6 +63,13 @@ it("should return all files from `docs` to validate", async () => {
 it("should return no files if no valid files to validate are found in paths", async () => {
   expect(await getFilesToValidate({ paths: ["some-folder"] })).toEqual([]);
 });
+it("should return no files from those matching the patterns declared in `exclude` option", async () => {
+  expect(await getFilesToValidate({ exclude: ["build", "tmp"] })).toEqual([
+    `${mockedCwd}/docs/index.html`,
+    `${mockedCwd}/docs/styles.css`,
+    `${mockedCwd}/docs/graphic.svg`
+  ]);
+});
 it("should return all HTML files to validate", async () => {
   expect(await getFilesToValidate({ languages: ["html"] })).toEqual([
     `${mockedCwd}/docs/index.html`,


### PR DESCRIPTION
These are the fixes:
- include the starting folder when beginning browsing recursively (the folders browsing did not include the root folder),
- only validate files whose filenames do not match the patterns in `exclude` option (the patterns were only checked on pathnames, which lead to validate files which were supposed to be excluded).