### PR TITLE
docs(contributing): update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,6 @@ Awesome! You are now able to contribute to markup-validator.
 - `pnpm lint`: checks linting errors only and fixes them,
 - `pnpm lint:check`: only checks linting errors,
 - `pnpm build`: runs the TypeScript compiler once,
-- `pnpm check-exports`: checks whether the package exports are correct,
 - `pnpm dev`: runs both the TypeScript compiler and the test suites in watch mode,
 - `pnpm tsc:watch`: runs the TypeScript compiler in watch mode,
 - `pnpm test`: runs the test suites once,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ Awesome! You are now able to contribute to markup-validator.
 
 #### Available commands
 
-- `pnpm biome`: checks linting and formating errors and fixes them,
-- `pnpm biome:check`: only checks linting and formating,
+- `pnpm biome`: checks imports organisation and linting and formating errors and fixes them,
+- `pnpm biome:check`: only checks imports organisation, linting and formating,
 - `pnpm format`: checks formating errors only and fixes them,
 - `pnpm format:check`: only checks formating errors,
 - `pnpm lint`: checks linting errors only and fixes them,


### PR DESCRIPTION
This document is updated by removing the mention of the `pnpm check-exports` command, which does not exist, and by adding a precision to the `pnpm biome` and `pnpm biome:check` commands, since they also check the way imports are organised.