### PR TITLE
test: make tests compliant with Vitest 4.1

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,19 +8,19 @@ import { mockedArgs } from "./utils/fixtures/mocked-args.js";
 
 let originalArgv: string[];
 
+vi.mock("../src/utils/show-help.js", () => ({ showHelp: vi.fn() }));
+vi.mock("../src/utils/show-version.js", () => ({ showVersion: vi.fn() }));
+vi.mock("../src/utils/parse-args.js", () => ({ parseArgs: vi.fn() }));
+vi.mock("../src/markup-validator.js", () => {
+  const MockClass = vi.fn();
+  MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
+  return { MarkupValidator: MockClass };
+});
+
 beforeEach(() => {
-  vi.mock("../src/utils/show-help.js", () => ({ showHelp: vi.fn() }));
-  vi.mock("../src/utils/show-version.js", () => ({ showVersion: vi.fn() }));
-  vi.mock("../src/utils/parse-args.js", () => ({ parseArgs: vi.fn() }));
-  vi.mock("../src/markup-validator.js", () => {
-    const MockClass = vi.fn();
-    MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
-    return { MarkupValidator: MockClass };
-  });
   originalArgv = process.argv;
 });
 afterEach(() => {
-  vi.clearAllMocks();
   process.argv = originalArgv;
 });
 

--- a/test/markup-validator.test.ts
+++ b/test/markup-validator.test.ts
@@ -12,26 +12,27 @@ import { HTMLValidator } from "../src/validators/html-validator.js";
 import { SVGValidator } from "../src/validators/svg-validator.js";
 import { mockedOptions } from "./fixtures/mocked-options.js";
 
+vi.mock("../src/utils/dry-run-notice.js", () => ({ dryRunNotice: vi.fn() }));
+vi.mock("../src/utils/get-files-to-validate.js", () => ({ getFilesToValidate: vi.fn() }));
+vi.mock("../src/utils/prepare-reporting.js", () => ({ prepareReporting: vi.fn() }));
+vi.mock("../src/utils/display-reporting.js", () => ({ displayReporting: vi.fn() }));
+vi.mock("../src/validators/html-validator.js", () => {
+  const MockClass = vi.fn();
+  MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
+  return { HTMLValidator: MockClass };
+});
+vi.mock("../src/validators/css-validator.js", () => {
+  const MockClass = vi.fn();
+  MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
+  return { CSSValidator: MockClass };
+});
+vi.mock("../src/validators/svg-validator.js", () => {
+  const MockClass = vi.fn();
+  MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
+  return { SVGValidator: MockClass };
+});
+
 beforeEach(() => {
-  vi.mock("../src/utils/dry-run-notice.js", () => ({ dryRunNotice: vi.fn() }));
-  vi.mock("../src/utils/get-files-to-validate.js", () => ({ getFilesToValidate: vi.fn() }));
-  vi.mock("../src/utils/prepare-reporting.js", () => ({ prepareReporting: vi.fn() }));
-  vi.mock("../src/utils/display-reporting.js", () => ({ displayReporting: vi.fn() }));
-  vi.mock("../src/validators/html-validator.js", () => {
-    const MockClass = vi.fn();
-    MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
-    return { HTMLValidator: MockClass };
-  });
-  vi.mock("../src/validators/css-validator.js", () => {
-    const MockClass = vi.fn();
-    MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
-    return { CSSValidator: MockClass };
-  });
-  vi.mock("../src/validators/svg-validator.js", () => {
-    const MockClass = vi.fn();
-    MockClass.prototype.validate = vi.fn().mockResolvedValue({ version: "1.0", messages: [] });
-    return { SVGValidator: MockClass };
-  });
   vi.useFakeTimers();
 });
 afterEach(() => {

--- a/test/markup-validator.test.ts
+++ b/test/markup-validator.test.ts
@@ -47,7 +47,7 @@ it.each(mockedOptions)("should instantiate the object with $0", options => {
   const markupValidator = new MarkupValidator(options);
   expect(markupValidator).toHaveProperty("options", options);
 });
-it("should skip validatation on dry-run mode", async () => {
+it("should skip validation on dry-run mode", async () => {
   const markupValidator = new MarkupValidator({ dryRun: true });
   await markupValidator.validate();
   expect(markupValidator).toHaveProperty("options", { dryRun: true });

--- a/test/utils/get-files-to-validate.test.ts
+++ b/test/utils/get-files-to-validate.test.ts
@@ -2,7 +2,7 @@ import type { Stats } from "node:fs";
 
 import fs from "node:fs/promises";
 
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
 
 import { browseFolders } from "../../src/utils/browse-folders.js";
 import { getFilesToValidate } from "../../src/utils/get-files-to-validate.js";
@@ -21,9 +21,10 @@ const mockedFiles: Record<string, string[]> = {
   "/fake/path/node_modules/dependency/docs": ["index.html", "styles.css", "graphic.svg"]
 };
 
+vi.mock("node:process", () => ({ cwd: vi.fn(() => mockedCwd) }));
+vi.mock("../../src/utils/browse-folders.js", () => ({ browseFolders: vi.fn() }));
+
 beforeEach(() => {
-  vi.mock("node:process", () => ({ cwd: vi.fn(() => mockedCwd) }));
-  vi.mock("../../src/utils/browse-folders.js", () => ({ browseFolders: vi.fn() }));
   vi.mocked(browseFolders).mockResolvedValue(mockedTree);
   vi.spyOn(fs, "readdir").mockImplementation(path => {
     const pathStr = path.toString();
@@ -37,9 +38,6 @@ beforeEach(() => {
       isFile: () => true
     } as Stats);
   });
-});
-afterEach(() => {
-  vi.clearAllMocks();
 });
 
 it("should return all files to validate", async () => {

--- a/test/utils/post-document-using-rest.test.ts
+++ b/test/utils/post-document-using-rest.test.ts
@@ -22,7 +22,7 @@ it("should throw an error if the response is not OK or has a non-200 status", ()
   );
   expect(
     postDocumentUsingRest(mockedEntryPoint, mockedDocument, mockedHTMLHeaders)
-  ).rejects.toThrowError("Failed to post the document: 404, Not Found.");
+  ).rejects.toThrow("Failed to post the document: 404, Not Found.");
 });
 it("should return the JSON data if the response is OK and has a 200 status", async () => {
   const mockedData = {

--- a/test/utils/prepare-reporting.test.ts
+++ b/test/utils/prepare-reporting.test.ts
@@ -1,16 +1,11 @@
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
 import { prepareReporting } from "../../src/utils/prepare-reporting.js";
 import { mockedCwd } from "./fixtures/mocked-cwd.js";
 import { mockedInvalidResultReporting } from "./fixtures/mocked-invalid-result-reporting.js";
 import { mockedValidResultReporting } from "./fixtures/mocked-valid-result-reporting.js";
 
-beforeEach(() => {
-  vi.mock("node:process", () => ({ cwd: vi.fn(() => mockedCwd) }));
-});
-afterEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("node:process", () => ({ cwd: vi.fn(() => mockedCwd) }));
 
 it.each([
   ...mockedValidResultReporting,

--- a/test/validators/css-validator.test.ts
+++ b/test/validators/css-validator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
 import { postDocumentUsingRest } from "../../src/utils/post-document-using-rest.js";
 import { CSSValidator } from "../../src/validators/css-validator.js";
@@ -6,14 +6,9 @@ import { mockedInvalidCSSFilesResults } from "../fixtures/mocked-invalid-css-fil
 import { mockedValidCSSFilesResults } from "../fixtures/mocked-valid-css-files-results.js";
 import { mockedCSSHeaders } from "../utils/fixtures/mocked-headers.js";
 
-beforeEach(() => {
-  vi.mock("../../src/utils/post-document-using-rest.js", () => ({
-    postDocumentUsingRest: vi.fn()
-  }));
-});
-afterEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("../../src/utils/post-document-using-rest.js", () => ({
+  postDocumentUsingRest: vi.fn()
+}));
 
 it("should be an instance of CSSValidator", () => {
   const cssValidator = new CSSValidator("fake-css-content");

--- a/test/validators/html-validator.test.ts
+++ b/test/validators/html-validator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
 import { postDocumentUsingRest } from "../../src/utils/post-document-using-rest.js";
 import { HTMLValidator } from "../../src/validators/html-validator.js";
@@ -6,14 +6,9 @@ import { mockedInvalidHTMLFilesResults } from "../fixtures/mocked-invalid-html-f
 import { mockedValidHTMLFilesResults } from "../fixtures/mocked-valid-html-files-results.js";
 import { mockedHTMLHeaders } from "../utils/fixtures/mocked-headers.js";
 
-beforeEach(() => {
-  vi.mock("../../src/utils/post-document-using-rest.js", () => ({
-    postDocumentUsingRest: vi.fn()
-  }));
-});
-afterEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("../../src/utils/post-document-using-rest.js", () => ({
+  postDocumentUsingRest: vi.fn()
+}));
 
 it("should be an instance of HTMLValidator", () => {
   const htmlValidator = new HTMLValidator("fake-html-content");

--- a/test/validators/svg-validator.test.ts
+++ b/test/validators/svg-validator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
 import { postDocumentUsingRest } from "../../src/utils/post-document-using-rest.js";
 import { SVGValidator } from "../../src/validators/svg-validator.js";
@@ -6,14 +6,9 @@ import { mockedInvalidSVGFilesResults } from "../fixtures/mocked-invalid-svg-fil
 import { mockedValidSVGFilesResults } from "../fixtures/mocked-valid-svg-files-results.js";
 import { mockedSVGHeaders } from "../utils/fixtures/mocked-headers.js";
 
-beforeEach(() => {
-  vi.mock("../../src/utils/post-document-using-rest.js", () => ({
-    postDocumentUsingRest: vi.fn()
-  }));
-});
-afterEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("../../src/utils/post-document-using-rest.js", () => ({
+  postDocumentUsingRest: vi.fn()
+}));
 
 it("should be an instance of SVGValidator", () => {
   const svgValidator = new SVGValidator("fake-svg-content");


### PR DESCRIPTION
There was a test using `toThrowError`. This alias for [`toThrow`](https://vitest.dev/api/expect.html#tothrow) is deprecated from now on.

Several tests used to nest `vi.mock` calls within `beforeEach`, which now triggers a warning like this:
> Warning: A vi.mock("node:process") call in "/Users/username/working-directory/markup-validator/test/utils/prepare-reporting.test.ts" is not at the top level of the module. Although it appears nested, it will be hoisted and executed before any tests run. Move it to the top level to reflect its actual execution order. This will become an error in a future version.
See: https://vitest.dev/guide/mocking/modules#how-it-works