### PR TITLE
chore(deps): remove @release-change/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@biomejs/biome": "2.4.8",
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
-    "@release-change/cli": "0.3.0",
     "@types/node": "24.12.0",
     "husky": "9.1.7",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@commitlint/config-conventional':
         specifier: 20.5.0
         version: 20.5.0
-      '@release-change/cli':
-        specifier: 0.3.0
-        version: 0.3.0
       '@types/node':
         specifier: 24.12.0
         version: 24.12.0
@@ -202,59 +199,6 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
-
-  '@release-change/ci@0.1.2':
-    resolution: {integrity: sha512-UXuoRZDC59z/AHnChvzFaeonrBKFBZjLRjbYN/QT44EWSXqRVKwunbhJNfyZ8H6FouE6zvkyiLRQdLR1EYKD0A==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/cli@0.3.0':
-    resolution: {integrity: sha512-rVIzEaQVLa/tMlkrJOLtBBJPzHnNhMqYuWktwlijTEl9SHuTEamFG6uXVgOmkgMxszdL5N5pzwqy263tO1++Hg==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.30.2'}
-    hasBin: true
-
-  '@release-change/commit-analyser@0.1.3':
-    resolution: {integrity: sha512-qIT8d7ocyMystwG+e6SKYLrUtJuijs2HrNryf3haUsnAZxFIGZ49889fp3xVaKYrYCyCTimjaMOg3PoEIBzzEQ==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/config@0.1.2':
-    resolution: {integrity: sha512-r232OsjWZgLMv4MpZKGGDxrOlBlE4Au42wJle7U9ge7oyaKtNsXbpsLD9f9iu9hnqoNkB1pI5jGJ/bxdB8arLQ==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/get-packages@0.1.2':
-    resolution: {integrity: sha512-tvWadeBTJYgR0VDbj2ov4wjDWMTjn9AnTKzYcrulusTsDiO2SLbBQsIpgq+x5gvHmMw5cxlHl41cStZZpoUFiw==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/git@0.2.0':
-    resolution: {integrity: sha512-AmYXvx/XjhfzhtAX4u3UhGFo0jm4hAFVLIIB+txRckqdsvVjWVG74GeXP4sLiNe1kS9d/XM7CRFcsEDQP2LOtA==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.30.2'}
-
-  '@release-change/github@0.1.4':
-    resolution: {integrity: sha512-WP0w38YS95BdZjdxFGW+fvkcJKIX5EPYnzRwuEGOLUG6v0T80az2tjC23r/jj49pZCcz2d2lWaniQ7irwibbCQ==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/logger@0.1.2':
-    resolution: {integrity: sha512-emk64Dzy1JUnHEi3HRq7nz5FSOQx1lSf/ADc5hp8kVRAoF2tijVQei3DHpOcRGZbkZVnzFE8O797TR+ppdNEtQ==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/npm@0.1.2':
-    resolution: {integrity: sha512-XO2IBzX65LAokGiIbVo1svxAGOU+2EVhyVOpcQ58+5wSCkU7hg1wPaPebu3PSJATS8LTyqkpFDkteLtHtgPIIA==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/release-notes-generator@0.1.5':
-    resolution: {integrity: sha512-tG9yg0vBWDV811UwIFIWsL5nlzsjgvCtKFUOL9W6fBPqSLJ2PqP70UNINx6z/qGB41MTCgoNiN9kbhAfapxDWQ==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.30.2'}
-
-  '@release-change/release@0.2.0':
-    resolution: {integrity: sha512-DaAdGSOqRt1yS7GdF7DCAGyzJgnsGIAzQKFczZ38MO6ifgQmB5MujVN/Xhi+NoiE11c2AOsU4byCVKayaujt3Q==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.30.2'}
-
-  '@release-change/semver@0.1.0':
-    resolution: {integrity: sha512-xMMNsJEJaZNyOOh2rvs2W4Nyw50Tw+est0p8KqiPImtsbe8cjTrBqdI16zzi5sjZJQU3IRfD/qLW1fdV3OafxA==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
-
-  '@release-change/shared@0.1.2':
-    resolution: {integrity: sha512-n8+1weDYmoxOlmTnPrdAa63UfeBf4w3a1FHftqgD3OzdCwBeg+4Itd5uTpzarG6hYk5pPN1zNlfWiwggcTI+BA==}
-    engines: {node: ^20.18.3 || ^22.12.0 || ^24.0.0, npm: '>=10.8.2', pnpm: '>=10.28.0'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
@@ -1100,95 +1044,6 @@ snapshots:
   '@oxc-project/runtime@0.115.0': {}
 
   '@oxc-project/types@0.115.0': {}
-
-  '@release-change/ci@0.1.2':
-    dependencies:
-      '@release-change/config': 0.1.2
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/cli@0.3.0':
-    dependencies:
-      '@release-change/ci': 0.1.2
-      '@release-change/commit-analyser': 0.1.3
-      '@release-change/config': 0.1.2
-      '@release-change/get-packages': 0.1.2
-      '@release-change/git': 0.2.0
-      '@release-change/github': 0.1.4
-      '@release-change/logger': 0.1.2
-      '@release-change/release': 0.2.0
-      '@release-change/semver': 0.1.0
-      '@release-change/shared': 0.1.2
-
-  '@release-change/commit-analyser@0.1.3':
-    dependencies:
-      '@release-change/config': 0.1.2
-      '@release-change/get-packages': 0.1.2
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/config@0.1.2':
-    dependencies:
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/get-packages@0.1.2':
-    dependencies:
-      '@release-change/config': 0.1.2
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/git@0.2.0':
-    dependencies:
-      '@release-change/commit-analyser': 0.1.3
-      '@release-change/logger': 0.1.2
-      '@release-change/semver': 0.1.0
-      '@release-change/shared': 0.1.2
-
-  '@release-change/github@0.1.4':
-    dependencies:
-      '@release-change/ci': 0.1.2
-      '@release-change/commit-analyser': 0.1.3
-      '@release-change/config': 0.1.2
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/logger@0.1.2':
-    dependencies:
-      '@release-change/shared': 0.1.2
-
-  '@release-change/npm@0.1.2':
-    dependencies:
-      '@release-change/config': 0.1.2
-      '@release-change/get-packages': 0.1.2
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/release-notes-generator@0.1.5':
-    dependencies:
-      '@release-change/ci': 0.1.2
-      '@release-change/commit-analyser': 0.1.3
-      '@release-change/get-packages': 0.1.2
-      '@release-change/github': 0.1.4
-      '@release-change/logger': 0.1.2
-      '@release-change/shared': 0.1.2
-
-  '@release-change/release@0.2.0':
-    dependencies:
-      '@release-change/commit-analyser': 0.1.3
-      '@release-change/config': 0.1.2
-      '@release-change/get-packages': 0.1.2
-      '@release-change/git': 0.2.0
-      '@release-change/github': 0.1.4
-      '@release-change/logger': 0.1.2
-      '@release-change/npm': 0.1.2
-      '@release-change/release-notes-generator': 0.1.5
-      '@release-change/semver': 0.1.0
-      '@release-change/shared': 0.1.2
-
-  '@release-change/semver@0.1.0': {}
-
-  '@release-change/shared@0.1.2': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true


### PR DESCRIPTION
Since release-change is run in CI environment, it is not needed as an installed dependency.
