### PR TITLE
chore(tsconfig): remove `strict` property

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
-    "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "types": ["node"],


### PR DESCRIPTION
Its default value is `true` in TS 6.

See https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/
