### PR TITLE
chore(pnpm): set `minimumReleaseAge` to 0

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 0
 allowBuilds:
   '@biomejs/biome': true
   esbuild: true


### PR DESCRIPTION
Since v11, its default value is 1440, which leads CI to fail because of newly updated dependencies.